### PR TITLE
Change to support dots in the keys and support overlapping dotted key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("src/jinja2/__init__.py", "rt", encoding="utf8") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read(), re.M).group(1)
 
 setup(
-    name="Jinja2-cb",
+    name="Jinja2",
     version=version,
     url="https://palletsprojects.com/p/jinja/",
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("src/jinja2/__init__.py", "rt", encoding="utf8") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read(), re.M).group(1)
 
 setup(
-    name="Jinja2",
+    name="Jinja2-cb",
     version=version,
     url="https://palletsprojects.com/p/jinja/",
     project_urls={

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -40,4 +40,4 @@ from .utils import evalcontextfunction
 from .utils import is_undefined
 from .utils import select_autoescape
 
-__version__ = "3.0.0a1-cb"
+__version__ = "3.0.0a1cb"

--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -40,4 +40,4 @@ from .utils import evalcontextfunction
 from .utils import is_undefined
 from .utils import select_autoescape
 
-__version__ = "3.0.0a1"
+__version__ = "3.0.0a1-cb"

--- a/src/jinja2/lexer.py
+++ b/src/jinja2/lexer.py
@@ -329,7 +329,9 @@ class TokenStream:
 
     def push(self, token):
         """Push a token back to the stream."""
-        self._pushed.append(token)
+        # CB Change.  Found that if you were pushing more than one token onto the stack
+        # it was getting pulled in backwards order.
+        self._pushed.appendleft(token)
 
     def look(self):
         """Look at the next token."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -295,14 +295,17 @@ class TestUndefined:
         logging_undefined = make_logging_undefined(DebugLogger())
         env = Environment(undefined=logging_undefined)
         assert env.from_string("{{ missing }}").render() == ""
-        pytest.raises(UndefinedError, env.from_string("{{ missing.attribute }}").render)
+        #CB change
+        # due to the change in variable resolution this would become ""
+        # and not raise an error.
+        assert env.from_string("{{ missing.attribute }}").render() == ""
         assert env.from_string("{{ missing|list }}").render() == "[]"
         assert env.from_string("{{ missing is not defined }}").render() == "True"
         assert env.from_string("{{ foo.missing }}").render(foo=42) == ""
         assert env.from_string("{{ not missing }}").render() == "True"
         assert _messages == [
             "W:Template variable warning: 'missing' is undefined",
-            "E:Template variable error: 'missing' is undefined",
+            "W:Template variable warning: 'missing' is undefined",
             "W:Template variable warning: 'missing' is undefined",
             "W:Template variable warning: 'int object' has no attribute 'missing'",
             "W:Template variable warning: 'missing' is undefined",
@@ -311,7 +314,10 @@ class TestUndefined:
     def test_default_undefined(self):
         env = Environment(undefined=Undefined)
         assert env.from_string("{{ missing }}").render() == ""
-        pytest.raises(UndefinedError, env.from_string("{{ missing.attribute }}").render)
+        #CB Change
+        # due to the change in variable resolution this would become ""
+        # and not raise an error.
+        assert env.from_string("{{ missing.attribute }}").render() == ""
         assert env.from_string("{{ missing|list }}").render() == "[]"
         assert env.from_string("{{ missing is not defined }}").render() == "True"
         assert env.from_string("{{ foo.missing }}").render(foo=42) == ""
@@ -354,7 +360,10 @@ class TestUndefined:
     def test_debug_undefined(self):
         env = Environment(undefined=DebugUndefined)
         assert env.from_string("{{ missing }}").render() == "{{ missing }}"
-        pytest.raises(UndefinedError, env.from_string("{{ missing.attribute }}").render)
+        #CB Change
+        # due to the change in variable resolution this would become "{{ missing }}"
+        # per the DebugUndefined and not raise an error.
+        assert env.from_string("{{ missing.attribute }}").render() == "{{ missing }}"
         assert env.from_string("{{ missing|list }}").render() == "[]"
         assert env.from_string("{{ missing is not defined }}").render() == "True"
         assert (

--- a/tests/test_dotted_names.py
+++ b/tests/test_dotted_names.py
@@ -1,0 +1,62 @@
+import itertools
+from importlib import reload
+from jinja2 import Template
+
+
+class Attributes:
+    a = "aaa"
+    b = {"next": "next level", "next.thing": "thing"}
+
+    def myfunc(self):
+        return "myfunc is called"
+
+class TestDottedNames:
+
+    def test_full_dot_key_match(self):
+        dict = {"level0": "000", "level0.level1": "abc", "level0.level1.level2": "def"}
+        t = Template("{{ level0.level1 }}")
+        out = t.render(dict)
+        assert out == "abc"
+        t = Template("{{ level0.level1.level2 }}")
+        out = t.render(dict)
+        assert out == "def"
+        t = Template("{{ level0 }}")
+        out = t.render(dict)
+        assert out == "000"
+
+    def test_dotted_nested(self):
+        dict2 = {"a": {"b": {"c.d": "e"}}}
+        t2 = Template("{{ a.b.c.d }}")
+        out2 = t2.render(dict2)
+        assert out2 == "e"
+
+    def test_dot_with_list(self):
+        dict = {"a.b": ["1a", "2a"], "a": "nothere"}
+        t = Template("{{a.b[0]}}")
+        out = t.render(dict)
+        assert out == "1a"
+        t = Template("{{a.b[0][1]}}")
+        out = t.render(dict)
+        assert out == "a"
+
+    def test_dot_with_attributes(self):
+        t = Template("{{ level0.level1.b.next }}")
+        ta = Attributes()
+        dict = {"level0": "000", "level0.level1": ta, "level0.level1.level2": "def"}
+        out = t.render(dict)
+        assert out == "next level"
+
+    def test_dot_with_attributes_return_dictStr(self):
+        t = Template("{{ level0.level1.b }}")
+        ta = Attributes()
+        dict = {"level0": "000", "level0.level1": ta, "level0.level1.level2": "def"}
+        out = t.render(dict)
+        assert out == str({"next": "next level", "next.thing": "thing"})
+
+    def test_names(self):
+        t = Template("{{ environment[0]|lower }}{{ platform[0:2]|lower}}{{ team[0]|lower "
+                     "}}{{ app|lower }}{% if os|lower == 'windows' %}11{% elif os|lower == "
+                     "'linux' %}15{% else %}17{% endif %}{{ sequence.MySequence }}")
+        dict = { "environment": "PROD", "platform": "Azure", "team": "DevOps", "os": "Windows", "app": "Web", "sequence.MySequence": "001"}
+        out = t.render(dict)
+        assert out == "pazdweb11001"


### PR DESCRIPTION
Change to support dots in the keys and support overlapping dotted key resolution due to dots in keynames.  Works from longest back to shortest path resolution to ensure fully dotted names are resolved first.

Note:  Cince this is a fork of jinja, I am going into cbdevelop to keep our development into one branch that we could then create a PR back to Jinja proper when we are completed with the changes necessary. ( making this an enablable feature )  