### PR TITLE
Fix for loop variable assignments ( right hand side ) to parse correctly

### DIFF
--- a/src/jinja2/__init__.py
+++ b/src/jinja2/__init__.py
@@ -40,4 +40,4 @@ from .utils import evalcontextfunction
 from .utils import is_undefined
 from .utils import select_autoescape
 
-__version__ = "3.0.0a1cb"
+__version__ = "3.0.0a2cb"

--- a/src/jinja2/parser.py
+++ b/src/jinja2/parser.py
@@ -205,10 +205,12 @@ class Parser:
         self.in_parse_for = True
         lineno = self.stream.expect("name:for").lineno
         target = self.parse_assign_target(extra_end_rules=("name:in",))
+        self.in_parse_for = False
         self.stream.expect("name:in")
         iter = self.parse_tuple(
             with_condexpr=False, extra_end_rules=("name:recursive",)
         )
+        self.in_parse_for = True
         test = None
         if self.stream.skip_if("name:if"):
             test = self.parse_expression()

--- a/tests/test_dotted_names.py
+++ b/tests/test_dotted_names.py
@@ -10,6 +10,7 @@ class Attributes:
     def myfunc(self):
         return "myfunc is called"
 
+
 class TestDottedNames:
 
     def test_full_dot_key_match(self):
@@ -54,9 +55,33 @@ class TestDottedNames:
         assert out == str({"next": "next level", "next.thing": "thing"})
 
     def test_names(self):
-        t = Template("{{ environment[0]|lower }}{{ platform[0:2]|lower}}{{ team[0]|lower "
-                     "}}{{ app|lower }}{% if os|lower == 'windows' %}11{% elif os|lower == "
-                     "'linux' %}15{% else %}17{% endif %}{{ sequence.MySequence }}")
-        dict = { "environment": "PROD", "platform": "Azure", "team": "DevOps", "os": "Windows", "app": "Web", "sequence.MySequence": "001"}
+        t = Template(
+            "{{ environment[0]|lower }}{{ platform[0:2]|lower}}{{ team[0]|lower "
+            "}}{{ app|lower }}{% if os|lower == 'windows' %}11{% elif os|lower == "
+            "'linux' %}15{% else %}17{% endif %}{{ sequence.MySequence }}")
+        dict = {"environment": "PROD", "platform": "Azure", "team": "DevOps",
+                "os": "Windows", "app": "Web", "sequence.MySequence": "001"}
         out = t.render(dict)
         assert out == "pazdweb11001"
+
+    def test_for(self):
+        template_test1 = "FOR:{% for key,val in level1.level2.level3.level4.level5.items() %} KEY: {{ key }} VAL: {{ val }} {% endfor %}"
+
+        result_test1 = "FOR: KEY: message VAL: Hello, World 2! "
+
+        dict = {
+            "level1.level2": {
+                "level3.level4.level5": {
+                    "message": "Hello, World!"
+                }
+            },
+            "level1.level2.level3": {
+                "level4.level5": {
+                    "message": "Hello, World 2!"
+                }
+            }
+        }
+
+        t = Template(template_test1)
+        out = t.render(dict)
+        assert out == result_test1


### PR DESCRIPTION
Found/Fixed a bug on the for loop parsing, if dots were in the right hand side they were not correctly resolved.  

